### PR TITLE
Update AMP config markup and add ability to disable endpoint

### DIFF
--- a/src/class-plugin-notice-controller.php
+++ b/src/class-plugin-notice-controller.php
@@ -141,6 +141,6 @@ class Plugin_Notice_Controller implements Integration {
 			}
 		}
 
-		wp_send_json( [ 'promptIfUnknown' => $active ], 200 );
+		wp_send_json( [ 'consentRequired' => $active ], 200 );
 	}
 }

--- a/src/cookie-notice/class-cookie-notice-amp-markup.php
+++ b/src/cookie-notice/class-cookie-notice-amp-markup.php
@@ -58,13 +58,25 @@ class Cookie_Notice_AMP_Markup extends Cookie_Notice_Markup {
 	 * @return array Data to pass to the `<amp-consent>` element.
 	 */
 	protected function get_consent_data() {
-		return array(
-			'consents' => array(
-				self::AMP_INSTANCE => array(
-					'checkConsentHref' => add_query_arg( 'action', self::AMP_CHECK_CONSENT_HREF_ACTION, admin_url( 'admin-ajax.php' ) ),
-					'promptUI'         => 'wp-gdpr-cookie-notice',
-				),
-			),
+		$consent_data = array(
+			'consentInstanceId' => self::AMP_INSTANCE,
+			'promptUI'          => 'wp-gdpr-cookie-notice',
 		);
+
+		/**
+		 * Filters whether to use an ajax endpoint for determining if the notice should be shown
+		 * or whether to use local storage to determine that.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param bool True if the endpoint should be used. False if local storage should be used.
+		 */
+		if ( apply_filters( 'wp_gdpr_cookie_notice_amp_use_endpoint', true ) ) {
+			$consent_data['checkConsentHref'] = add_query_arg( 'action', self::AMP_CHECK_CONSENT_HREF_ACTION, admin_url( 'admin-ajax.php' ) );
+		} else {
+			$consent_data['consentRequired'] = true;
+		}
+
+		return $consent_data;
 	}
 }


### PR DESCRIPTION
<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.8 and PHP 5.6.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Description

Closes #8 

This PR makes two small changes to the AMP handling in this plugin:

1. It updates the configuration to use `consentRequired` instead of the deprecated `promptIfUnknown`. It also refactors the configuration to [remove the deprecated `consents` object](https://github.com/ampproject/amphtml/issues/29662#issuecomment-669330546).

2. It adds a filter to allow disabling the ajax endpoint that determines whether to show the notice, and instead use local storage for determining whether to show the notice. If you think it makes sense, I'm happy to update this PR to make the local storage approach the default way or to remove the endpoint entirely and always use local storage. The underlying reason for the local storage approach is that firing an un-cacheable ajax request on every pageload causes scalability issues on high-traffic sites.

## How Has This Been Tested? / Screenshots (jpeg or gifs if applicable):

1. In a new incognito window, go to a page with the network inspector open. Observe an ajax request gets fired and the notice displays:
<img width="1659" alt="Screen Shot 2020-08-13 at 10 57 04 AM" src="https://user-images.githubusercontent.com/7317227/90172158-70a55c80-dd57-11ea-9c05-dc456c82acd7.png">

2. Accept the notice. Refresh the page or go to another page. Observe an ajax request gets fired and the notice doesn't display:
<img width="1648" alt="Screen Shot 2020-08-13 at 10 57 32 AM" src="https://user-images.githubusercontent.com/7317227/90172164-726f2000-dd57-11ea-8fae-ff5e2bc4b737.png">

3. Add the following somewhere: `add_filter( 'wp_gdpr_cookie_notice_amp_use_endpoint', '__return_false' );`

4. In a new incognito window, go to a page with the network inspector open. Observe no ajax request gets fired and the notice displays:
<img width="1651" alt="Screen Shot 2020-08-13 at 10 58 06 AM" src="https://user-images.githubusercontent.com/7317227/90172170-74d17a00-dd57-11ea-9014-3f0215a9633f.png">

5. Accept the notice. Refresh the page or go to another page. Observe no ajax request gets fired and the notice doesn't display:
<img width="1648" alt="Screen Shot 2020-08-13 at 10 58 19 AM" src="https://user-images.githubusercontent.com/7317227/90172189-7bf88800-dd57-11ea-988c-61061b865658.png">

## Types of changes
Bug fix (update deprecated config) and performance improvement (endpoint filter)

## Checklist:
- [x] My code is tested.
- [x] My code is backward-compatible with WordPress 4.9.6 and PHP 7.0.
- [x] My code follows the WordPress coding standards.
- [x] My code has proper inline documentation.
