### PR TITLE
Hide cookie notice panel in printed output.

### DIFF
--- a/src/cookie-notice/class-cookie-notice-stylesheet.php
+++ b/src/cookie-notice/class-cookie-notice-stylesheet.php
@@ -388,12 +388,6 @@ class Cookie_Notice_Stylesheet implements Inline_Asset {
 			color: <?php echo esc_attr( $options[ self::SETTING_BUTTON_TEXT_COLOR ] ); ?>;
 			background-color: <?php echo esc_attr( $this->darken_color( $options[ self::SETTING_BUTTON_BACKGROUND_COLOR ], 25 ) ); ?>;
 		}
-
-		@media print {
-			.wp-gdpr-cookie-notice {
-				display: none;
-			}
-		}
 		<?php
 	}
 

--- a/src/cookie-notice/class-cookie-notice-stylesheet.php
+++ b/src/cookie-notice/class-cookie-notice-stylesheet.php
@@ -388,6 +388,12 @@ class Cookie_Notice_Stylesheet implements Inline_Asset {
 			color: <?php echo esc_attr( $options[ self::SETTING_BUTTON_TEXT_COLOR ] ); ?>;
 			background-color: <?php echo esc_attr( $this->darken_color( $options[ self::SETTING_BUTTON_BACKGROUND_COLOR ], 25 ) ); ?>;
 		}
+
+		@media print {
+			.wp-gdpr-cookie-notice {
+				display: none;
+			}
+		}
 		<?php
 	}
 


### PR DESCRIPTION

## Description

Hides the cookie notice when printing the web page.

## How Has This Been Tested?

CSS only change; tested in browser only. Test run: https://github.com/joedolson/wp-gdpr-cookie-notice/actions

## Screenshots (jpeg or gifs if applicable):

Not applicable. Change is the absence of the cookie notice.

## Types of changes

I'd consider this a bug fix, as it removes an obstruction of content in print views.

## Checklist:
- [x ] My code is tested.
- [ x] My code is backward-compatible with WordPress 4.9.6 and PHP 7.0.
- [ x] My code follows the WordPress coding standards.
- [x ] My code has proper inline documentation.
